### PR TITLE
PS4 joystick teleop

### DIFF
--- a/turtlebot3_teleop/CMakeLists.txt
+++ b/turtlebot3_teleop/CMakeLists.txt
@@ -8,8 +8,10 @@ project(turtlebot3_teleop)
 # Packages
 ################################################################################
 find_package(catkin REQUIRED COMPONENTS
+  roscpp
   rospy
   geometry_msgs
+  joy
 )
 
 ################################################################################

--- a/turtlebot3_teleop/README.md
+++ b/turtlebot3_teleop/README.md
@@ -1,0 +1,41 @@
+Install
+---
+Install the dependent packages.
+
+Install the joy package.
+```sh
+sudo apt-get install ros-kinetic-joy
+```
+
+Install the Dual Shock 4 driver. 
+https://github.com/chrippa/ds4drv
+
+Build this package
+
+for catkin_make user
+```sh
+cd $HOME/your_catkin_ws
+catkin make
+```
+
+OR
+
+for catkin tools user
+```sh
+cd $HOME/your_catkin_ws
+catkin build turtlebot3_teleop
+```
+
+---
+
+Test
+---
+How to test the ps4 teleop.
+
+Pair the joy stick with your PC. 
+See: https://github.com/chrippa/ds4drv
+
+Launch the teleop node.
+```sh
+roslaunch turtlebot3_teleop ps4_teleop.launch
+```

--- a/turtlebot3_teleop/launch/ps4_teleop.launch
+++ b/turtlebot3_teleop/launch/ps4_teleop.launch
@@ -1,0 +1,16 @@
+<launch>
+  <!--  smooths inputs from cmd_vel_mux/input/teleop_raw to cmd_vel_mux/input/teleop -->
+  <!-- <include file="$(find turtlebot_teleop)/launch/includes/velocity_smoother.launch.xml"/> -->
+
+  <node pkg="turtlebot_teleop" type="turtlebot_teleop_joy" name="turtlebot_teleop_joystick">
+    <param name="scale_angular" value="1.5"/>
+    <param name="scale_linear" value="0.5"/>
+    <param name="axis_deadman" value="0"/>
+    <param name="axis_linear" value="1"/>
+    <param name="axis_angular" value="0"/>
+    <remap from="turtlebot_teleop_joystick/cmd_vel" to="/cmd_vel"/>
+  </node>
+
+  <node pkg="joy" type="joy_node" name="joystick"/>
+
+</launch>

--- a/turtlebot3_teleop/package.xml
+++ b/turtlebot3_teleop/package.xml
@@ -13,8 +13,12 @@
   <url type="repository">https://github.com/ROBOTIS-GIT/turtlebot3</url>
   <url type="website">http://turtlebot3.robotis.com</url>
   <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>roscpp</build_depend>
   <build_depend>rospy</build_depend>
   <build_depend>geometry_msgs</build_depend>
+  <build_depend>joy</build_depend>
+  <run_depend>roscpp</run_depend>
   <run_depend>rospy</run_depend>
   <run_depend>geometry_msgs</run_depend>
+  <run_depend>joy</run_depend>
 </package>

--- a/turtlebot3_teleop/src/turtlebot_joy.cpp
+++ b/turtlebot3_teleop/src/turtlebot_joy.cpp
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2010, Willow Garage, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <ros/ros.h>
+#include <geometry_msgs/Twist.h>
+#include <sensor_msgs/Joy.h>
+#include "boost/thread/mutex.hpp"
+#include "boost/thread/thread.hpp"
+#include "ros/console.h"
+
+class TurtlebotTeleop
+{
+public:
+  TurtlebotTeleop();
+
+private:
+  void joyCallback(const sensor_msgs::Joy::ConstPtr& joy);
+  void publish();
+
+  ros::NodeHandle ph_, nh_;
+
+  int linear_, angular_, deadman_axis_;
+  double l_scale_, a_scale_;
+  ros::Publisher vel_pub_;
+  ros::Subscriber joy_sub_;
+
+  geometry_msgs::Twist last_published_;
+  boost::mutex publish_mutex_;
+  bool deadman_pressed_;
+  bool zero_twist_published_;
+  ros::Timer timer_;
+
+};
+
+TurtlebotTeleop::TurtlebotTeleop():
+  ph_("~"),
+  linear_(1),
+  angular_(0),
+  deadman_axis_(4),
+  l_scale_(0.3),
+  a_scale_(0.9)
+{
+  ph_.param("axis_linear", linear_, linear_);
+  ph_.param("axis_angular", angular_, angular_);
+  ph_.param("axis_deadman", deadman_axis_, deadman_axis_);
+  ph_.param("scale_angular", a_scale_, a_scale_);
+  ph_.param("scale_linear", l_scale_, l_scale_);
+
+  deadman_pressed_ = false;
+  zero_twist_published_ = false;
+
+  vel_pub_ = ph_.advertise<geometry_msgs::Twist>("cmd_vel", 1, true);
+  joy_sub_ = nh_.subscribe<sensor_msgs::Joy>("joy", 10, &TurtlebotTeleop::joyCallback, this);
+
+  timer_ = nh_.createTimer(ros::Duration(0.1), boost::bind(&TurtlebotTeleop::publish, this));
+}
+
+void TurtlebotTeleop::joyCallback(const sensor_msgs::Joy::ConstPtr& joy)
+{ 
+  geometry_msgs::Twist vel;
+  vel.angular.z = a_scale_*joy->axes[angular_];
+  vel.linear.x = l_scale_*joy->axes[linear_];
+  last_published_ = vel;
+  deadman_pressed_ = joy->buttons[deadman_axis_];
+}
+
+void TurtlebotTeleop::publish()
+{
+  boost::mutex::scoped_lock lock(publish_mutex_);
+
+  if (deadman_pressed_)
+  {
+    vel_pub_.publish(last_published_);
+    zero_twist_published_=false;
+  }
+  else if(!deadman_pressed_ && !zero_twist_published_)
+  {
+    vel_pub_.publish(*new geometry_msgs::Twist());
+    zero_twist_published_=true;
+  }
+}
+
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "turtlebot_teleop");
+  TurtlebotTeleop turtlebot_teleop;
+
+  ros::spin();
+}


### PR DESCRIPTION
Added turtlebot_joy node, appropriate dependencies, and README.md file.

This let us use PS4 joystick for tele-operation of TB3.