### PR TITLE
Fix turtlebot3 dependencies

### DIFF
--- a/turtlebot3/package.xml
+++ b/turtlebot3/package.xml
@@ -24,5 +24,6 @@
   <exec_depend>turtlebot3_navigation</exec_depend>
   <exec_depend>turtlebot3_slam</exec_depend>
   <exec_depend>turtlebot3_teleop</exec_depend>
+  <exec_depend>turtlebot3_msgs</exec_depend>
   <export><metapackage/></export>
 </package>


### PR DESCRIPTION
Trying to `catkin build turtlebot3` gives the following error
```
error: ‘const struct turtlebot3_msgs::SensorState_<std::allocator<void>’ has no member named ‘torque’ 
if (msg->torque == true)
```
Which is caused by lack of dependency on `turtlebot3_msgs`.

Although it builds fine with `catkin_make`, it should be better to have clear dependencies for each package.