### PR TITLE
Corret the laser scanner update_rate in the gazebo xacro files

### DIFF
--- a/turtlebot3_description/urdf/turtlebot3_burger.gazebo.xacro
+++ b/turtlebot3_description/urdf/turtlebot3_burger.gazebo.xacro
@@ -125,7 +125,7 @@
       <plugin name="gazebo_ros_lds_lfcd_controller" filename="libgazebo_ros_laser.so">
         <topicName>scan</topicName>
         <frameName>base_scan</frameName>
-        <update_rate>1800</update_rate>
+        <update_rate>5</update_rate>
       </plugin>
     </sensor>
   </gazebo>

--- a/turtlebot3_description/urdf/turtlebot3_burger_for_autorace.gazebo.xacro
+++ b/turtlebot3_description/urdf/turtlebot3_burger_for_autorace.gazebo.xacro
@@ -125,7 +125,7 @@
       <plugin name="gazebo_ros_lds_lfcd_controller" filename="libgazebo_ros_laser.so">
         <topicName>scan</topicName>
         <frameName>base_scan</frameName>
-        <update_rate>1800</update_rate>
+        <update_rate>5</update_rate>
       </plugin>
     </sensor>
   </gazebo>

--- a/turtlebot3_description/urdf/turtlebot3_waffle.gazebo.xacro
+++ b/turtlebot3_description/urdf/turtlebot3_waffle.gazebo.xacro
@@ -136,7 +136,7 @@
       <plugin name="gazebo_ros_lds_lfcd_controller" filename="libgazebo_ros_laser.so">
         <topicName>scan</topicName>
         <frameName>base_scan</frameName>
-        <update_rate>1800</update_rate>
+        <update_rate>5</update_rate>
       </plugin>
     </sensor>
   </gazebo>

--- a/turtlebot3_description/urdf/turtlebot3_waffle_pi.gazebo.xacro
+++ b/turtlebot3_description/urdf/turtlebot3_waffle_pi.gazebo.xacro
@@ -136,7 +136,7 @@
       <plugin name="gazebo_ros_lds_lfcd_controller" filename="libgazebo_ros_laser.so">
         <topicName>scan</topicName>
         <frameName>base_scan</frameName>
-        <update_rate>1800</update_rate>
+        <update_rate>5</update_rate>
       </plugin>
     </sensor>
   </gazebo>


### PR DESCRIPTION
According to the issue #253, change the update_rate from 1800 to 5.