### PR TITLE
Replace a hard coded path with the default path of  `image` in map.yaml.

### DIFF
--- a/turtlebot3_navigation/maps/map.yaml
+++ b/turtlebot3_navigation/maps/map.yaml
@@ -1,4 +1,4 @@
-image: /home/pyo/map.pgm
+image: map.pgm
 resolution: 0.050000
 origin: [-10.000000, -10.000000, 0.000000]
 negate: 0


### PR DESCRIPTION
When turtlebot3_navigation.launch is run, an error will occur with default `map_file` param.
The file path in map.yaml is odd. 