### PR TITLE
Enable turtlebot teleop

### DIFF
--- a/turtlebot3_bringup/src/turtlebot3_diagnostics.cpp
+++ b/turtlebot3_bringup/src/turtlebot3_diagnostics.cpp
@@ -107,32 +107,32 @@ void setButtonDiagnosis(uint8_t level, std::string message)
 
 void imuMsgCallback(const sensor_msgs::Imu::ConstPtr &msg)
 {
-  setIMUDiagnosis(diagnostic_msgs::DiagnosticStatus::OK, "Good Condition");
+  setIMUDiagnosis(diagnostic_msgs::DiagnosticStatus::DIAG_OK, "Good Condition");
 }
 
 void LDSMsgCallback(const sensor_msgs::LaserScan::ConstPtr &msg)
 {
-  setLDSDiagnosis(diagnostic_msgs::DiagnosticStatus::OK, "Good Condition");
+  setLDSDiagnosis(diagnostic_msgs::DiagnosticStatus::DIAG_OK, "Good Condition");
 }
 
 void sensorStateMsgCallback(const turtlebot3_msgs::SensorState::ConstPtr &msg)
 {
   if (msg->battery > 11.0)
-    setBatteryDiagnosis(diagnostic_msgs::DiagnosticStatus::OK, "Good Condition");
+    setBatteryDiagnosis(diagnostic_msgs::DiagnosticStatus::DIAG_OK, "Good Condition");
   else
-    setBatteryDiagnosis(diagnostic_msgs::DiagnosticStatus::WARN, "Charge!!! Charge!!!");
+    setBatteryDiagnosis(diagnostic_msgs::DiagnosticStatus::DIAG_WARN, "Charge!!! Charge!!!");
 
   if (msg->button == turtlebot3_msgs::SensorState::BUTTON0)
-    setButtonDiagnosis(diagnostic_msgs::DiagnosticStatus::OK, "BUTTON 0 IS PUSHED");
+    setButtonDiagnosis(diagnostic_msgs::DiagnosticStatus::DIAG_OK, "BUTTON 0 IS PUSHED");
   else if (msg->button == turtlebot3_msgs::SensorState::BUTTON1)
-    setButtonDiagnosis(diagnostic_msgs::DiagnosticStatus::OK, "BUTTON 1 IS PUSHED");
+    setButtonDiagnosis(diagnostic_msgs::DiagnosticStatus::DIAG_OK, "BUTTON 1 IS PUSHED");
   else
-    setButtonDiagnosis(diagnostic_msgs::DiagnosticStatus::OK, "Pushed Nothing");
+    setButtonDiagnosis(diagnostic_msgs::DiagnosticStatus::DIAG_OK, "Pushed Nothing");
 
-  if (msg->torque == true)
-    setMotorDiagnosis(diagnostic_msgs::DiagnosticStatus::OK, "Torque ON");
+  if (!!(msg->torque) == true)
+    setMotorDiagnosis(diagnostic_msgs::DiagnosticStatus::DIAG_OK, "Torque ON");
   else
-    setMotorDiagnosis(diagnostic_msgs::DiagnosticStatus::WARN, "Torque OFF");
+    setMotorDiagnosis(diagnostic_msgs::DiagnosticStatus::DIAG_WARN, "Torque OFF");
 }
 
 void firmwareVersionMsgCallback(const turtlebot3_msgs::VersionInfo::ConstPtr &msg)

--- a/turtlebot3_teleop/CMakeLists.txt
+++ b/turtlebot3_teleop/CMakeLists.txt
@@ -40,7 +40,7 @@ catkin_package(
 # Install
 ################################################################################
 catkin_install_python(PROGRAMS
-  nodes/turtlebot3_teleop_key
+  nodes/turtlebot3_teleop_key.py
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 

--- a/turtlebot3_teleop/launch/turtlebot3_teleop_key.launch
+++ b/turtlebot3_teleop/launch/turtlebot3_teleop_key.launch
@@ -3,6 +3,6 @@
   <param name="model" value="$(arg model)"/>
 
   <!-- turtlebot3_teleop_key already has its own built in velocity smoother -->
-  <node pkg="turtlebot3_teleop" type="turtlebot3_teleop_key" name="turtlebot3_teleop_keyboard"  output="screen">
+  <node pkg="turtlebot3_teleop" type="turtlebot3_teleop_key.py" name="turtlebot3_teleop_keyboard"  output="screen">
   </node>
 </launch>

--- a/turtlebot3_teleop/nodes/turtlebot3_teleop_key.py
+++ b/turtlebot3_teleop/nodes/turtlebot3_teleop_key.py
@@ -29,7 +29,11 @@
 
 import rospy
 from geometry_msgs.msg import Twist
-import sys, select, termios, tty
+import sys, select, os
+if os.name == 'nt':
+  import msvcrt
+else:
+  import tty, termios
 
 BURGER_MAX_LIN_VEL = 0.22
 BURGER_MAX_ANG_VEL = 2.84
@@ -61,6 +65,9 @@ Communications Failed
 """
 
 def getKey():
+    if os.name == 'nt':
+      return msvcrt.getch()
+
     tty.setraw(sys.stdin.fileno())
     rlist, _, _ = select.select([sys.stdin], [], [], 0.1)
     if rlist:
@@ -115,7 +122,8 @@ def checkAngularLimitVelocity(vel):
     return vel
 
 if __name__=="__main__":
-    settings = termios.tcgetattr(sys.stdin)
+    if os.name != 'nt':
+        settings = termios.tcgetattr(sys.stdin)
 
     rospy.init_node('turtlebot3_teleop')
     pub = rospy.Publisher('cmd_vel', Twist, queue_size=10)
@@ -181,4 +189,5 @@ if __name__=="__main__":
         twist.angular.x = 0.0; twist.angular.y = 0.0; twist.angular.z = 0.0
         pub.publish(twist)
 
-    termios.tcsetattr(sys.stdin, termios.TCSADRAIN, settings)
+    if os.name != 'nt':
+        termios.tcsetattr(sys.stdin, termios.TCSADRAIN, settings)


### PR DESCRIPTION
Modified the launch file to use .py extension which is portable across Windows and Linux.  Fixed the use of termios in the teleoperation script.