### PR TITLE
Add use_gui arg to turtlebot3_model.launch

### DIFF
--- a/turtlebot3_bringup/launch/turtlebot3_model.launch
+++ b/turtlebot3_bringup/launch/turtlebot3_model.launch
@@ -1,17 +1,16 @@
 <launch>
   <arg name="model" default="$(env TURTLEBOT3_MODEL)" doc="model type [burger, waffle, waffle_pi]"/>
+  <arg name="multi_robot_name" default=""/>
+  <arg name="test" default="false"/>
 
-  <include file="$(find turtlebot3_bringup)/launch/includes/description.launch.xml">
+  <include file="$(find turtlebot3_bringup)/launch/turtlebot3_remote.launch">
     <arg name="model" value="$(arg model)" />
+    <arg name="multi_robot_name" value="$(arg multi_robot_name)"/>
   </include>
 
-  <node pkg="joint_state_publisher" type="joint_state_publisher" name="joint_state_publisher">
+  <node if="$(arg test)" pkg="joint_state_publisher" type="joint_state_publisher" name="joint_state_publisher">
     <param name="use_gui" value="true"/>
     <param name="rate" value="50"/>
-  </node>
-
-  <node pkg="robot_state_publisher" type="robot_state_publisher" name="robot_state_publisher">
-    <param name="publish_frequency" type="double" value="50.0" />
   </node>
 
   <node name="rviz" pkg="rviz" type="rviz" args="-d $(find turtlebot3_description)/rviz/model.rviz"/>


### PR DESCRIPTION
~This allows to use:~  
~$ export TURTLEBOT3_MODEL=${TB3_MODEL}
$ roslaunch turtlebot3_bringup turtlebot3_model.launch use_gui:=false~

Instead of:
```bash
$ export TURTLEBOT3_MODEL=${TB3_MODEL}
$ roslaunch turtlebot3_bringup turtlebot3_remote.launch
$ rosrun rviz rviz -d `rospack find turtlebot3_description`/rviz/model.rviz
```

An advantage is that the user does not need to write the backticks. This follows the concept of the `slam `and `navigation `launch files, which already includes the remote and rviz-config.

~The default of the new arg is set to "true" to make it compatible with the current launch file. Since I have not seen this launch file being used in the docs, one could also consider to set the default to "false".~


Also, I reused/included the `remote.launch` to replace the `description.launch` and `robot_state_publisher`.