### PR TITLE
Added an additional argument move_forward_only to prohibit backward l…

### DIFF
--- a/turtlebot3_navigation/launch/move_base.launch
+++ b/turtlebot3_navigation/launch/move_base.launch
@@ -3,6 +3,7 @@
   <arg name="model" default="$(env TURTLEBOT3_MODEL)" doc="model type [burger, waffle, waffle_pi]"/>
   <arg name="cmd_vel_topic" default="/cmd_vel" />
   <arg name="odom_topic" default="odom" />
+  <arg name="move_forward_only" default="false"/>
 
   <!-- move_base -->
   <node pkg="move_base" type="move_base" respawn="false" name="move_base" output="screen">
@@ -15,5 +16,6 @@
     <rosparam file="$(find turtlebot3_navigation)/param/dwa_local_planner_params_$(arg model).yaml" command="load" />
     <remap from="cmd_vel" to="$(arg cmd_vel_topic)"/>
     <remap from="odom" to="$(arg odom_topic)"/>
+    <param name="DWAPlannerROS/min_vel_x" value="0.0" if="$(arg move_forward_only)" />
   </node>
 </launch>

--- a/turtlebot3_navigation/launch/turtlebot3_navigation.launch
+++ b/turtlebot3_navigation/launch/turtlebot3_navigation.launch
@@ -3,6 +3,7 @@
   <arg name="model" default="$(env TURTLEBOT3_MODEL)" doc="model type [burger, waffle, waffle_pi]"/>
   <arg name="map_file" default="$(find turtlebot3_navigation)/maps/map.yaml"/>
   <arg name="open_rviz" default="true"/>
+  <arg name="move_forward_only" default="false"/>
 
   <!-- Turtlebot3 -->
   <include file="$(find turtlebot3_bringup)/launch/turtlebot3_remote.launch">
@@ -18,6 +19,7 @@
   <!-- move_base -->
   <include file="$(find turtlebot3_navigation)/launch/move_base.launch">
     <arg name="model" value="$(arg model)" />
+    <arg name="move_forward_only" value="$(arg move_forward_only)"/>
   </include>
 
   <!-- rviz -->


### PR DESCRIPTION
This PR is the resolution for #330 . 

If you set:
move_forward_only:=true

TB3 goes from the wheel base side only (no backward locomotion).