### PR TITLE
updated map.yaml

### DIFF
--- a/turtlebot3_navigation2/map/map.yaml
+++ b/turtlebot3_navigation2/map/map.yaml
@@ -1,4 +1,4 @@
-image: ~/map.pgm
+image: map.pgm
 resolution: 0.050000
 origin: [-10.000000, -10.000000, 0.000000]
 negate: 0


### PR DESCRIPTION
update map.pgm relative path

Without this change, the map server crashes with the following error

`
[ERROR] [map_server]: failed to open image file "/root/turtlebot3_ws/install/turtlebot3_navigation2/share/turtlebot3_navigation2/map/~/map.pgm": Couldn't open /root/turtlebot3_ws/install/turtlebot3_navigation2/share/turtlebot3_navigation2/map/~/map.pgm`
