### PR TITLE
delete '/' to sync tf2

### DIFF
--- a/turtlebot3_navigation/param/global_costmap_params.yaml
+++ b/turtlebot3_navigation/param/global_costmap_params.yaml
@@ -1,6 +1,6 @@
 global_costmap:
-  global_frame: /map
-  robot_base_frame: /base_footprint
+  global_frame: map
+  robot_base_frame: base_footprint
 
   update_frequency: 10.0
   publish_frequency: 10.0

--- a/turtlebot3_navigation/param/local_costmap_params.yaml
+++ b/turtlebot3_navigation/param/local_costmap_params.yaml
@@ -1,6 +1,6 @@
 local_costmap:
-  global_frame: /odom
-  robot_base_frame: /base_footprint
+  global_frame: odom
+  robot_base_frame: base_footprint
 
   update_frequency: 10.0
   publish_frequency: 10.0


### PR DESCRIPTION
To support tf2, I deleted slash in front of topic name where it had set in global and local costmap param.yaml.

https://github.com/ros-planning/navigation/issues/794