### PR TITLE
Fix ROS2 dependencies and library install

### DIFF
--- a/turtlebot3_bringup/package.xml
+++ b/turtlebot3_bringup/package.xml
@@ -14,6 +14,8 @@
   <url type="repository">https://github.com/ROBOTIS-GIT/turtlebot3</url>
   <url type="bugtracker">https://github.com/ROBOTIS-GIT/turtlebot3/issues</url>
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <depend>turtlebot3_description</depend>
+  <depend>turtlebot3_node</depend>
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/turtlebot3_node/CMakeLists.txt
+++ b/turtlebot3_node/CMakeLists.txt
@@ -50,7 +50,7 @@ add_library(${PROJECT_NAME}_LIB SHARED
   "src/odometry.cpp"
 )
 
-set(DEPENDENCIES 
+set(DEPENDENCIES
   "rclcpp"
   "std_msgs"
   "sensor_msgs"
@@ -74,6 +74,13 @@ ament_target_dependencies(${EXECUTABLE_NAME} ${dependencies})
 ################################################################################
 # Install
 ################################################################################
+install(TARGETS
+  ${PROJECT_NAME}_LIB
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
 install(TARGETS
   ${EXECUTABLE_NAME}
   DESTINATION lib/${PROJECT_NAME}


### PR DESCRIPTION
Problem: If I tried `colcon build --packages-up-to turtlebot3_bringup`, the launch would fail because the package dependencies were incomplete. 

Problem: If I did a `colcon build --packages-up-to turtlebot3_node` then tried to `ros2 run turtlebot3_node turtlebot3_ros`, it would fail to find the library because it was not installed to the install directory.