### PR TITLE
[ros2][turtlebot3_navigation2] pass use_sim_time argument to rviz2 node

### DIFF
--- a/turtlebot3_navigation2/launch/navigation2.launch.py
+++ b/turtlebot3_navigation2/launch/navigation2.launch.py
@@ -66,5 +66,6 @@ def generate_launch_description():
             node_executable='rviz2',
             node_name='rviz2',
             arguments=['-d', rviz_config_dir],
+            parameters=[{'use_sim_time': use_sim_time}],
             output='screen'),
     ])


### PR DESCRIPTION
This reduces the number of tf errors printed in terminal when running `turtlebot3_navigation` along `turtlebot3_gazebo`

Signed-off-by: Mikael Arguedas <mikael.arguedas@gmail.com>