### PR TITLE
Update turtlebot3_description CMakeLists.txt

### DIFF
--- a/turtlebot3_description/CMakeLists.txt
+++ b/turtlebot3_description/CMakeLists.txt
@@ -48,6 +48,5 @@ install(DIRECTORY meshes rviz urdf
 ################################################################################
 # Macro for ament package
 ################################################################################
-ament_export_dependencies(xacro)
 ament_export_dependencies(urdf)
 ament_package()


### PR DESCRIPTION
Removed ament_export_dependency(xacro) as xacro is a python package that is not installed or depends on it.
Is there a reason for keeping it here?