### PR TITLE
Add dwa_local_planner to package dependencies

### DIFF
--- a/turtlebot3_navigation/package.xml
+++ b/turtlebot3_navigation/package.xml
@@ -19,5 +19,6 @@
   <exec_depend>amcl</exec_depend>
   <exec_depend>map_server</exec_depend>
   <exec_depend>move_base</exec_depend>
+  <exec_depend>dwa_local_planner</exec_depend>
   <exec_depend>turtlebot3_bringup</exec_depend>
 </package>


### PR DESCRIPTION
When launching this package on a fresh install of Ubuntu 18.04 + ROS Melodic with the following command:

```
roslaunch turtlebot3_navigation turtlebot3_navigation.launch map_file:=`pwd`/mapfile.yaml
```

I received the following error:

```
[FATAL] [1569807689.247752052, 814.494000000]: Failed to create the dwa_local_planner/DWAPlannerROS planner, are you sure it is properly registered and that the containing library is built? Exception: According to the loaded plugin descriptions the class dwa_local_planner/DWAPlannerROS with base class type nav_core::BaseLocalPlanner does not exist. Declared types are  base_local_planner/TrajectoryPlannerROS
```

I found the forum thread https://answers.ros.org/question/266411/navigation-problem-with-cob3-dwaplanerros-create-fail/ which mentioned it's because dwa_local_planner is not installed. 

Installing `ros-melodic-dwa-local-planner` fixed the issue, so I'm adding it to the package.xml as it is required for navigation planning. 

