### PR TITLE
[eloquent] Fix the nav2_default_view.rviz location.

### DIFF
--- a/turtlebot3_navigation2/launch/navigation2.launch.py
+++ b/turtlebot3_navigation2/launch/navigation2.launch.py
@@ -47,7 +47,7 @@ def generate_launch_description():
 
     rviz_config_dir = os.path.join(
         get_package_share_directory('nav2_bringup'),
-        'launch',
+        'rviz',
         'nav2_default_view.rviz')
 
     return LaunchDescription([


### PR DESCRIPTION
This is found when I tried to exercise this example: http://emanual.robotis.com/docs/en/platform/turtlebot3/ros2_simulation/#virtual-navigation-with-turtlebot3

The file is under `rviz` subfolder.
https://github.com/ros-planning/navigation2/blob/eloquent-devel/nav2_bringup/bringup/rviz/nav2_default_view.rviz