### PR TITLE
Fix gmapping launch

### DIFF
--- a/turtlebot3_slam/launch/turtlebot3_gmapping.launch
+++ b/turtlebot3_slam/launch/turtlebot3_gmapping.launch
@@ -1,6 +1,7 @@
 <launch>
   <!-- Arguments -->
   <arg name="model" default="$(env TURTLEBOT3_MODEL)" doc="model type [burger, waffle, waffle_pi]"/>
+  <arg name="configuration_basename" default="turtlebot3_lds_2d.lua"/>
   <arg name="set_base_frame" default="base_footprint"/>
   <arg name="set_odom_frame" default="odom"/>
   <arg name="set_map_frame"  default="map"/>


### PR DESCRIPTION
This PR reverts commit a8e7647d809497612ff82b564a55ba17c5b5e2a3 introduced in #577.

Launching `roslaunch turtlebot3 turtlebot3_slam.launch slam_methods:=gmapping` results in the following launch error:

```terminal
roslaunch.core.RLException: unused args [configuration_basename] for include of [/opt/ros/melodic/share/turtlebot3_slam/launch/turtlebot3_gmapping.launch]
```

This PR fixes that. 

Sorry for the inconvenience.