### PR TITLE
Make turtlebot3_navigation2 Apply Parameters

### DIFF
--- a/turtlebot3_navigation2/launch/navigation2.launch.py
+++ b/turtlebot3_navigation2/launch/navigation2.launch.py
@@ -71,7 +71,7 @@ def generate_launch_description():
             launch_arguments={
                 'map': map_dir,
                 'use_sim_time': use_sim_time,
-                'params': param_dir}.items(),
+                'params_file': param_dir}.items(),
         ),
 
         Node(

--- a/turtlebot3_navigation2/param/burger.yaml
+++ b/turtlebot3_navigation2/param/burger.yaml
@@ -49,68 +49,122 @@ amcl_rclcpp_node:
 bt_navigator:
   ros__parameters:
     use_sim_time: False
-    bt_xml_filename: "bt_navigator.xml"
+    global_frame: map
+    robot_base_frame: base_link
+    odom_topic: /odom
+    default_bt_xml_filename: "navigate_w_replanning_and_recovery.xml"
+    plugin_lib_names:
+    - nav2_compute_path_to_pose_action_bt_node
+    - nav2_follow_path_action_bt_node
+    - nav2_back_up_action_bt_node
+    - nav2_spin_action_bt_node
+    - nav2_wait_action_bt_node
+    - nav2_clear_costmap_service_bt_node
+    - nav2_is_stuck_condition_bt_node
+    - nav2_goal_reached_condition_bt_node
+    - nav2_goal_updated_condition_bt_node
+    - nav2_initial_pose_received_condition_bt_node
+    - nav2_reinitialize_global_localization_service_bt_node
+    - nav2_rate_controller_bt_node
+    - nav2_distance_controller_bt_node
+    - nav2_speed_controller_bt_node
+    - nav2_recovery_node_bt_node
+    - nav2_pipeline_sequence_bt_node
+    - nav2_round_robin_node_bt_node
+    - nav2_transform_available_condition_bt_node
+    - nav2_time_expired_condition_bt_node
+    - nav2_distance_traveled_condition_bt_node
 
-dwb_controller:
+bt_navigator_rclcpp_node:
   ros__parameters:
     use_sim_time: False
-    debug_trajectory_details: True
-    min_vel_x: 0.0
-    min_vel_y: 0.0
-    max_vel_x: 0.22
-    max_vel_y: 0.0
-    max_vel_theta: 1.0
-    min_speed_xy: 0.0
-    max_speed_xy: 0.22
-    min_speed_theta: 0.0
+
+controller_server:
+  ros__parameters:
+    use_sim_time: False
+    controller_frequency: 20.0
     min_x_velocity_threshold: 0.001
-    # Add high threshold velocity for turtlebot 3 issue.
-    # https://github.com/ROBOTIS-GIT/turtlebot3_simulations/issues/75
     min_y_velocity_threshold: 0.5
     min_theta_velocity_threshold: 0.001
-    acc_lim_x: 2.5
-    acc_lim_y: 0.0
-    acc_lim_theta: 3.2
-    decel_lim_x: -2.5
-    decel_lim_y: 0.0
-    decel_lim_theta: -3.2
-    vx_samples: 20
-    vy_samples: 5
-    vtheta_samples: 20
-    sim_time: 1.7
-    linear_granularity: 0.05
-    xy_goal_tolerance: 0.25
-    transform_tolerance: 0.2
-    critics: ["RotateToGoal", "Oscillation", "BaseObstacle", "GoalAlign", "PathAlign", "PathDist", "GoalDist"]
-    BaseObstacle.scale: 0.02
-    PathAlign.scale: 0.0
-    GoalAlign.scale: 0.0
-    PathDist.scale: 32.0
-    GoalDist.scale: 24.0
-    RotateToGoal.scale: 32.0
+    controller_plugins: ["FollowPath"]
+
+    # DWB parameters
+    FollowPath:
+      plugin: "dwb_core::DWBLocalPlanner"
+      debug_trajectory_details: True
+      min_vel_x: 0.0
+      min_vel_y: 0.0
+      max_vel_x: 0.22
+      max_vel_y: 0.0
+      max_vel_theta: 1.0
+      min_speed_xy: 0.0
+      max_speed_xy: 0.22
+      min_speed_theta: 0.0
+      # Add high threshold velocity for turtlebot 3 issue.
+      # https://github.com/ROBOTIS-GIT/turtlebot3_simulations/issues/75
+      acc_lim_x: 2.5
+      acc_lim_y: 0.0
+      acc_lim_theta: 3.2
+      decel_lim_x: -2.5
+      decel_lim_y: 0.0
+      decel_lim_theta: -3.2
+      vx_samples: 20
+      vy_samples: 5
+      vtheta_samples: 20
+      sim_time: 1.7
+      linear_granularity: 0.05
+      angular_granularity: 0.025
+      transform_tolerance: 0.2
+      xy_goal_tolerance: 0.25
+      trans_stopped_velocity: 0.25
+      short_circuit_trajectory_evaluation: True
+      stateful: True
+      critics: ["RotateToGoal", "Oscillation", "BaseObstacle", "GoalAlign", "PathAlign", "PathDist", "GoalDist"]
+      BaseObstacle.scale: 0.02
+      PathAlign.scale: 32.0
+      PathAlign.forward_point_distance: 0.1
+      GoalAlign.scale: 24.0
+      GoalAlign.forward_point_distance: 0.1
+      PathDist.scale: 32.0
+      GoalDist.scale: 24.0
+      RotateToGoal.scale: 32.0
+      RotateToGoal.slowing_factor: 5.0
+      RotateToGoal.lookahead_time: -1.0
+
+controller_server_rclcpp_node:
+  ros__parameters:
+    use_sim_time: False
 
 local_costmap:
   local_costmap:
     ros__parameters:
-      use_sim_time: False
+      update_frequency: 5.0
+      publish_frequency: 2.0
       global_frame: odom
-      plugin_names: ["obstacle_layer", "inflation_layer"]
-      plugin_types: ["nav2_costmap_2d::ObstacleLayer", "nav2_costmap_2d::InflationLayer"]
+      robot_base_frame: base_link
+      use_sim_time: False
       rolling_window: true
       width: 3
       height: 3
       resolution: 0.05
       robot_radius: 0.105
-      inflation_layer.cost_scaling_factor: 3.0
+      plugins: ["obstacle_layer", "inflation_layer"]
+      inflation_layer:
+        plugin: "nav2_costmap_2d::InflationLayer"
+        cost_scaling_factor: 3.0
       obstacle_layer:
+        plugin: "nav2_costmap_2d::ObstacleLayer"
         enabled: True
+        observation_sources: scan
+        scan:
+          topic: /scan
+          max_obstacle_height: 2.0
+          clearing: True
+          marking: True
+          data_type: "LaserScan"
+      static_layer:
+        map_subscribe_transient_local: True
       always_send_full_costmap: True
-      observation_sources: scan
-      scan:
-        topic: /scan
-        max_obstacle_height: 2.0
-        clearing: True
-        marking: True
   local_costmap_client:
     ros__parameters:
       use_sim_time: False
@@ -121,17 +175,30 @@ local_costmap:
 global_costmap:
   global_costmap:
     ros__parameters:
+      update_frequency: 1.0
+      publish_frequency: 1.0
+      global_frame: map
+      robot_base_frame: base_link
       use_sim_time: False
       robot_radius: 0.105
+      resolution: 0.05
+      plugins: ["static_layer", "obstacle_layer", "inflation_layer"]
       obstacle_layer:
+        plugin: "nav2_costmap_2d::ObstacleLayer"
         enabled: True
+        observation_sources: scan
+        scan:
+          topic: /scan
+          max_obstacle_height: 2.0
+          clearing: True
+          marking: True
+          data_type: "LaserScan"
+      static_layer:
+        plugin: "nav2_costmap_2d::StaticLayer"
+        map_subscribe_transient_local: True
+      inflation_layer:
+        plugin: "nav2_costmap_2d::InflationLayer"
       always_send_full_costmap: True
-      observation_sources: scan
-      scan:
-        topic: /scan
-        max_obstacle_height: 2.0
-        clearing: True
-        marking: True
   global_costmap_client:
     ros__parameters:
       use_sim_time: False
@@ -144,36 +211,50 @@ map_server:
     use_sim_time: False
     yaml_filename: "map.yaml"
 
-lifecycle_manager:
+map_saver:
   ros__parameters:
     use_sim_time: False
-    autostart: True
-    node_names: ['map_server', 'amcl',
-                 'world_model', 'dwb_controller',
-                 'navfn_planner', 'bt_navigator']
+    save_map_timeout: 5000
+    free_thresh_default: 0.25
+    occupied_thresh_default: 0.65
+    map_subscribe_transient_local: True
 
-lifecycle_manager_service_client:
+planner_server:
+  ros__parameters:
+    expected_planner_frequency: 20.0
+    use_sim_time: False
+    planner_plugins: ["GridBased"]
+    GridBased:
+      plugin: "nav2_navfn_planner/NavfnPlanner"
+      tolerance: 0.0
+      use_astar: false
+      allow_unknown: true
+
+planner_server_rclcpp_node:
   ros__parameters:
     use_sim_time: False
 
-lifecycle_manager_client_service_client:
+recoveries_server:
   ros__parameters:
+    costmap_topic: local_costmap/costmap_raw
+    footprint_topic: local_costmap/published_footprint
+    cycle_frequency: 10.0
+    recovery_plugins: ["spin", "backup", "wait"]
+    spin:
+      plugin: "nav2_recoveries/Spin"
+    backup:
+      plugin: "nav2_recoveries/BackUp"
+    wait:
+      plugin: "nav2_recoveries/Wait"
+    global_frame: odom
+    robot_base_frame: base_link
+    transform_timeout: 0.1
     use_sim_time: False
-
-navfn_planner:
-  ros__parameters:
-    use_sim_time: False
-    tolerance: 0.0
-    use_astar: false
-
-navfn_planner_GetCostmap_client:
-  ros__parameters:
-    use_sim_time: False
+    simulate_ahead_time: 2.0
+    max_rotational_vel: 1.0
+    min_rotational_vel: 0.4
+    rotational_acc_lim: 3.2
 
 robot_state_publisher:
-  ros__parameters:
-    use_sim_time: False
-
-world_model:
   ros__parameters:
     use_sim_time: False

--- a/turtlebot3_navigation2/param/waffle.yaml
+++ b/turtlebot3_navigation2/param/waffle.yaml
@@ -49,68 +49,122 @@ amcl_rclcpp_node:
 bt_navigator:
   ros__parameters:
     use_sim_time: False
-    bt_xml_filename: "bt_navigator.xml"
+    global_frame: map
+    robot_base_frame: base_link
+    odom_topic: /odom
+    default_bt_xml_filename: "navigate_w_replanning_and_recovery.xml"
+    plugin_lib_names:
+    - nav2_compute_path_to_pose_action_bt_node
+    - nav2_follow_path_action_bt_node
+    - nav2_back_up_action_bt_node
+    - nav2_spin_action_bt_node
+    - nav2_wait_action_bt_node
+    - nav2_clear_costmap_service_bt_node
+    - nav2_is_stuck_condition_bt_node
+    - nav2_goal_reached_condition_bt_node
+    - nav2_goal_updated_condition_bt_node
+    - nav2_initial_pose_received_condition_bt_node
+    - nav2_reinitialize_global_localization_service_bt_node
+    - nav2_rate_controller_bt_node
+    - nav2_distance_controller_bt_node
+    - nav2_speed_controller_bt_node
+    - nav2_recovery_node_bt_node
+    - nav2_pipeline_sequence_bt_node
+    - nav2_round_robin_node_bt_node
+    - nav2_transform_available_condition_bt_node
+    - nav2_time_expired_condition_bt_node
+    - nav2_distance_traveled_condition_bt_node
 
-dwb_controller:
+bt_navigator_rclcpp_node:
   ros__parameters:
     use_sim_time: False
-    debug_trajectory_details: True
-    min_vel_x: 0.0
-    min_vel_y: 0.0
-    max_vel_x: 0.26
-    max_vel_y: 0.0
-    max_vel_theta: 1.0
-    min_speed_xy: 0.0
-    max_speed_xy: 0.26
-    min_speed_theta: 0.0
+
+controller_server:
+  ros__parameters:
+    use_sim_time: False
+    controller_frequency: 20.0
     min_x_velocity_threshold: 0.001
-    # Add high threshold velocity for turtlebot 3 issue.
-    # https://github.com/ROBOTIS-GIT/turtlebot3_simulations/issues/75
     min_y_velocity_threshold: 0.5
     min_theta_velocity_threshold: 0.001
-    acc_lim_x: 2.5
-    acc_lim_y: 0.0
-    acc_lim_theta: 3.2
-    decel_lim_x: -2.5
-    decel_lim_y: 0.0
-    decel_lim_theta: -3.2
-    vx_samples: 20
-    vy_samples: 5
-    vtheta_samples: 20
-    sim_time: 1.7
-    linear_granularity: 0.05
-    xy_goal_tolerance: 0.25
-    transform_tolerance: 0.2
-    critics: ["RotateToGoal", "Oscillation", "BaseObstacle", "GoalAlign", "PathAlign", "PathDist", "GoalDist"]
-    BaseObstacle.scale: 0.02
-    PathAlign.scale: 0.0
-    GoalAlign.scale: 0.0
-    PathDist.scale: 32.0
-    GoalDist.scale: 24.0
-    RotateToGoal.scale: 32.0
+    controller_plugins: ["FollowPath"]
+
+    # DWB parameters
+    FollowPath:
+      plugin: "dwb_core::DWBLocalPlanner"
+      debug_trajectory_details: True
+      min_vel_x: 0.0
+      min_vel_y: 0.0
+      max_vel_x: 0.26
+      max_vel_y: 0.0
+      max_vel_theta: 1.0
+      min_speed_xy: 0.0
+      max_speed_xy: 0.26
+      min_speed_theta: 0.0
+      # Add high threshold velocity for turtlebot 3 issue.
+      # https://github.com/ROBOTIS-GIT/turtlebot3_simulations/issues/75
+      acc_lim_x: 2.5
+      acc_lim_y: 0.0
+      acc_lim_theta: 3.2
+      decel_lim_x: -2.5
+      decel_lim_y: 0.0
+      decel_lim_theta: -3.2
+      vx_samples: 20
+      vy_samples: 5
+      vtheta_samples: 20
+      sim_time: 1.7
+      linear_granularity: 0.05
+      angular_granularity: 0.025
+      transform_tolerance: 0.2
+      xy_goal_tolerance: 0.25
+      trans_stopped_velocity: 0.25
+      short_circuit_trajectory_evaluation: True
+      stateful: True
+      critics: ["RotateToGoal", "Oscillation", "BaseObstacle", "GoalAlign", "PathAlign", "PathDist", "GoalDist"]
+      BaseObstacle.scale: 0.02
+      PathAlign.scale: 32.0
+      PathAlign.forward_point_distance: 0.1
+      GoalAlign.scale: 24.0
+      GoalAlign.forward_point_distance: 0.1
+      PathDist.scale: 32.0
+      GoalDist.scale: 24.0
+      RotateToGoal.scale: 32.0
+      RotateToGoal.slowing_factor: 5.0
+      RotateToGoal.lookahead_time: -1.0
+
+controller_server_rclcpp_node:
+  ros__parameters:
+    use_sim_time: False
 
 local_costmap:
   local_costmap:
     ros__parameters:
-      use_sim_time: False
+      update_frequency: 5.0
+      publish_frequency: 2.0
       global_frame: odom
-      plugin_names: ["obstacle_layer", "inflation_layer"]
-      plugin_types: ["nav2_costmap_2d::ObstacleLayer", "nav2_costmap_2d::InflationLayer"]
+      robot_base_frame: base_link
+      use_sim_time: False
       rolling_window: true
       width: 3
       height: 3
       resolution: 0.05
       robot_radius: 0.22
-      inflation_layer.cost_scaling_factor: 3.0
+      plugins: ["obstacle_layer", "inflation_layer"]
+      inflation_layer:
+        plugin: "nav2_costmap_2d::InflationLayer"
+        cost_scaling_factor: 3.0
       obstacle_layer:
+        plugin: "nav2_costmap_2d::ObstacleLayer"
         enabled: True
+        observation_sources: scan
+        scan:
+          topic: /scan
+          max_obstacle_height: 2.0
+          clearing: True
+          marking: True
+          data_type: "LaserScan"
+      static_layer:
+        map_subscribe_transient_local: True
       always_send_full_costmap: True
-      observation_sources: scan
-      scan:
-        topic: /scan
-        max_obstacle_height: 2.0
-        clearing: True
-        marking: True
   local_costmap_client:
     ros__parameters:
       use_sim_time: False
@@ -121,17 +175,30 @@ local_costmap:
 global_costmap:
   global_costmap:
     ros__parameters:
+      update_frequency: 1.0
+      publish_frequency: 1.0
+      global_frame: map
+      robot_base_frame: base_link
       use_sim_time: False
       robot_radius: 0.22
+      resolution: 0.05
+      plugins: ["static_layer", "obstacle_layer", "inflation_layer"]
       obstacle_layer:
+        plugin: "nav2_costmap_2d::ObstacleLayer"
         enabled: True
+        observation_sources: scan
+        scan:
+          topic: /scan
+          max_obstacle_height: 2.0
+          clearing: True
+          marking: True
+          data_type: "LaserScan"
+      static_layer:
+        plugin: "nav2_costmap_2d::StaticLayer"
+        map_subscribe_transient_local: True
+      inflation_layer:
+        plugin: "nav2_costmap_2d::InflationLayer"
       always_send_full_costmap: True
-      observation_sources: scan
-      scan:
-        topic: /scan
-        max_obstacle_height: 2.0
-        clearing: True
-        marking: True
   global_costmap_client:
     ros__parameters:
       use_sim_time: False
@@ -144,36 +211,50 @@ map_server:
     use_sim_time: False
     yaml_filename: "map.yaml"
 
-lifecycle_manager:
+map_saver:
   ros__parameters:
     use_sim_time: False
-    autostart: True
-    node_names: ['map_server', 'amcl',
-                 'world_model', 'dwb_controller',
-                 'navfn_planner', 'bt_navigator']
+    save_map_timeout: 5000
+    free_thresh_default: 0.25
+    occupied_thresh_default: 0.65
+    map_subscribe_transient_local: True
 
-lifecycle_manager_service_client:
+planner_server:
+  ros__parameters:
+    expected_planner_frequency: 20.0
+    use_sim_time: False
+    planner_plugins: ["GridBased"]
+    GridBased:
+      plugin: "nav2_navfn_planner/NavfnPlanner"
+      tolerance: 0.0
+      use_astar: false
+      allow_unknown: true
+
+planner_server_rclcpp_node:
   ros__parameters:
     use_sim_time: False
 
-lifecycle_manager_client_service_client:
+recoveries_server:
   ros__parameters:
+    costmap_topic: local_costmap/costmap_raw
+    footprint_topic: local_costmap/published_footprint
+    cycle_frequency: 10.0
+    recovery_plugins: ["spin", "backup", "wait"]
+    spin:
+      plugin: "nav2_recoveries/Spin"
+    backup:
+      plugin: "nav2_recoveries/BackUp"
+    wait:
+      plugin: "nav2_recoveries/Wait"
+    global_frame: odom
+    robot_base_frame: base_link
+    transform_timeout: 0.1
     use_sim_time: False
-
-navfn_planner:
-  ros__parameters:
-    use_sim_time: False
-    tolerance: 0.0
-    use_astar: false
-
-navfn_planner_GetCostmap_client:
-  ros__parameters:
-    use_sim_time: False
+    simulate_ahead_time: 2.0
+    max_rotational_vel: 1.0
+    min_rotational_vel: 0.4
+    rotational_acc_lim: 3.2
 
 robot_state_publisher:
-  ros__parameters:
-    use_sim_time: False
-
-world_model:
   ros__parameters:
     use_sim_time: False

--- a/turtlebot3_navigation2/param/waffle_pi.yaml
+++ b/turtlebot3_navigation2/param/waffle_pi.yaml
@@ -49,68 +49,122 @@ amcl_rclcpp_node:
 bt_navigator:
   ros__parameters:
     use_sim_time: False
-    bt_xml_filename: "bt_navigator.xml"
+    global_frame: map
+    robot_base_frame: base_link
+    odom_topic: /odom
+    default_bt_xml_filename: "navigate_w_replanning_and_recovery.xml"
+    plugin_lib_names:
+    - nav2_compute_path_to_pose_action_bt_node
+    - nav2_follow_path_action_bt_node
+    - nav2_back_up_action_bt_node
+    - nav2_spin_action_bt_node
+    - nav2_wait_action_bt_node
+    - nav2_clear_costmap_service_bt_node
+    - nav2_is_stuck_condition_bt_node
+    - nav2_goal_reached_condition_bt_node
+    - nav2_goal_updated_condition_bt_node
+    - nav2_initial_pose_received_condition_bt_node
+    - nav2_reinitialize_global_localization_service_bt_node
+    - nav2_rate_controller_bt_node
+    - nav2_distance_controller_bt_node
+    - nav2_speed_controller_bt_node
+    - nav2_recovery_node_bt_node
+    - nav2_pipeline_sequence_bt_node
+    - nav2_round_robin_node_bt_node
+    - nav2_transform_available_condition_bt_node
+    - nav2_time_expired_condition_bt_node
+    - nav2_distance_traveled_condition_bt_node
 
-dwb_controller:
+bt_navigator_rclcpp_node:
   ros__parameters:
     use_sim_time: False
-    debug_trajectory_details: True
-    min_vel_x: 0.0
-    min_vel_y: 0.0
-    max_vel_x: 0.26
-    max_vel_y: 0.0
-    max_vel_theta: 1.0
-    min_speed_xy: 0.0
-    max_speed_xy: 0.26
-    min_speed_theta: 0.0
+
+controller_server:
+  ros__parameters:
+    use_sim_time: False
+    controller_frequency: 20.0
     min_x_velocity_threshold: 0.001
-    # Add high threshold velocity for turtlebot 3 issue.
-    # https://github.com/ROBOTIS-GIT/turtlebot3_simulations/issues/75
     min_y_velocity_threshold: 0.5
     min_theta_velocity_threshold: 0.001
-    acc_lim_x: 2.5
-    acc_lim_y: 0.0
-    acc_lim_theta: 3.2
-    decel_lim_x: -2.5
-    decel_lim_y: 0.0
-    decel_lim_theta: -3.2
-    vx_samples: 20
-    vy_samples: 5
-    vtheta_samples: 20
-    sim_time: 1.7
-    linear_granularity: 0.05
-    xy_goal_tolerance: 0.25
-    transform_tolerance: 0.2
-    critics: ["RotateToGoal", "Oscillation", "BaseObstacle", "GoalAlign", "PathAlign", "PathDist", "GoalDist"]
-    BaseObstacle.scale: 0.02
-    PathAlign.scale: 0.0
-    GoalAlign.scale: 0.0
-    PathDist.scale: 32.0
-    GoalDist.scale: 24.0
-    RotateToGoal.scale: 32.0
+    controller_plugins: ["FollowPath"]
+
+    # DWB parameters
+    FollowPath:
+      plugin: "dwb_core::DWBLocalPlanner"
+      debug_trajectory_details: True
+      min_vel_x: 0.0
+      min_vel_y: 0.0
+      max_vel_x: 0.26
+      max_vel_y: 0.0
+      max_vel_theta: 1.0
+      min_speed_xy: 0.0
+      max_speed_xy: 0.26
+      min_speed_theta: 0.0
+      # Add high threshold velocity for turtlebot 3 issue.
+      # https://github.com/ROBOTIS-GIT/turtlebot3_simulations/issues/75
+      acc_lim_x: 2.5
+      acc_lim_y: 0.0
+      acc_lim_theta: 3.2
+      decel_lim_x: -2.5
+      decel_lim_y: 0.0
+      decel_lim_theta: -3.2
+      vx_samples: 20
+      vy_samples: 5
+      vtheta_samples: 20
+      sim_time: 1.7
+      linear_granularity: 0.05
+      angular_granularity: 0.025
+      transform_tolerance: 0.2
+      xy_goal_tolerance: 0.25
+      trans_stopped_velocity: 0.25
+      short_circuit_trajectory_evaluation: True
+      stateful: True
+      critics: ["RotateToGoal", "Oscillation", "BaseObstacle", "GoalAlign", "PathAlign", "PathDist", "GoalDist"]
+      BaseObstacle.scale: 0.02
+      PathAlign.scale: 32.0
+      PathAlign.forward_point_distance: 0.1
+      GoalAlign.scale: 24.0
+      GoalAlign.forward_point_distance: 0.1
+      PathDist.scale: 32.0
+      GoalDist.scale: 24.0
+      RotateToGoal.scale: 32.0
+      RotateToGoal.slowing_factor: 5.0
+      RotateToGoal.lookahead_time: -1.0
+
+controller_server_rclcpp_node:
+  ros__parameters:
+    use_sim_time: False
 
 local_costmap:
   local_costmap:
     ros__parameters:
-      use_sim_time: False
+      update_frequency: 5.0
+      publish_frequency: 2.0
       global_frame: odom
-      plugin_names: ["obstacle_layer", "inflation_layer"]
-      plugin_types: ["nav2_costmap_2d::ObstacleLayer", "nav2_costmap_2d::InflationLayer"]
+      robot_base_frame: base_link
+      use_sim_time: False
       rolling_window: true
       width: 3
       height: 3
       resolution: 0.05
       robot_radius: 0.22
-      inflation_layer.cost_scaling_factor: 3.0
+      plugins: ["obstacle_layer", "inflation_layer"]
+      inflation_layer:
+        plugin: "nav2_costmap_2d::InflationLayer"
+        cost_scaling_factor: 3.0
       obstacle_layer:
+        plugin: "nav2_costmap_2d::ObstacleLayer"
         enabled: True
+        observation_sources: scan
+        scan:
+          topic: /scan
+          max_obstacle_height: 2.0
+          clearing: True
+          marking: True
+          data_type: "LaserScan"
+      static_layer:
+        map_subscribe_transient_local: True
       always_send_full_costmap: True
-      observation_sources: scan
-      scan:
-        topic: /scan
-        max_obstacle_height: 2.0
-        clearing: True
-        marking: True
   local_costmap_client:
     ros__parameters:
       use_sim_time: False
@@ -121,17 +175,30 @@ local_costmap:
 global_costmap:
   global_costmap:
     ros__parameters:
+      update_frequency: 1.0
+      publish_frequency: 1.0
+      global_frame: map
+      robot_base_frame: base_link
       use_sim_time: False
       robot_radius: 0.22
+      resolution: 0.05
+      plugins: ["static_layer", "obstacle_layer", "inflation_layer"]
       obstacle_layer:
+        plugin: "nav2_costmap_2d::ObstacleLayer"
         enabled: True
+        observation_sources: scan
+        scan:
+          topic: /scan
+          max_obstacle_height: 2.0
+          clearing: True
+          marking: True
+          data_type: "LaserScan"
+      static_layer:
+        plugin: "nav2_costmap_2d::StaticLayer"
+        map_subscribe_transient_local: True
+      inflation_layer:
+        plugin: "nav2_costmap_2d::InflationLayer"
       always_send_full_costmap: True
-      observation_sources: scan
-      scan:
-        topic: /scan
-        max_obstacle_height: 2.0
-        clearing: True
-        marking: True
   global_costmap_client:
     ros__parameters:
       use_sim_time: False
@@ -144,36 +211,50 @@ map_server:
     use_sim_time: False
     yaml_filename: "map.yaml"
 
-lifecycle_manager:
+map_saver:
   ros__parameters:
     use_sim_time: False
-    autostart: True
-    node_names: ['map_server', 'amcl',
-                 'world_model', 'dwb_controller',
-                 'navfn_planner', 'bt_navigator']
+    save_map_timeout: 5000
+    free_thresh_default: 0.25
+    occupied_thresh_default: 0.65
+    map_subscribe_transient_local: True
 
-lifecycle_manager_service_client:
+planner_server:
+  ros__parameters:
+    expected_planner_frequency: 20.0
+    use_sim_time: False
+    planner_plugins: ["GridBased"]
+    GridBased:
+      plugin: "nav2_navfn_planner/NavfnPlanner"
+      tolerance: 0.0
+      use_astar: false
+      allow_unknown: true
+
+planner_server_rclcpp_node:
   ros__parameters:
     use_sim_time: False
 
-lifecycle_manager_client_service_client:
+recoveries_server:
   ros__parameters:
+    costmap_topic: local_costmap/costmap_raw
+    footprint_topic: local_costmap/published_footprint
+    cycle_frequency: 10.0
+    recovery_plugins: ["spin", "backup", "wait"]
+    spin:
+      plugin: "nav2_recoveries/Spin"
+    backup:
+      plugin: "nav2_recoveries/BackUp"
+    wait:
+      plugin: "nav2_recoveries/Wait"
+    global_frame: odom
+    robot_base_frame: base_link
+    transform_timeout: 0.1
     use_sim_time: False
-
-navfn_planner:
-  ros__parameters:
-    use_sim_time: False
-    tolerance: 0.0
-    use_astar: false
-
-navfn_planner_GetCostmap_client:
-  ros__parameters:
-    use_sim_time: False
+    simulate_ahead_time: 2.0
+    max_rotational_vel: 1.0
+    min_rotational_vel: 0.4
+    rotational_acc_lim: 3.2
 
 robot_state_publisher:
-  ros__parameters:
-    use_sim_time: False
-
-world_model:
   ros__parameters:
     use_sim_time: False


### PR DESCRIPTION
Navigation2 parameters given in e.g. `/turtlebot3_navigation2/param/burger.yaml` are not applied as a wrong argument (`params` instead of `params_file`) is used for `nav2_bringup bringup_launch.py`.

The `params_file` argument declaration of `nav2_bringup bringup_launch.py` is available here:
https://github.com/ros-planning/navigation2/blob/aa9394a6b57a23ede7add9cbba901ba1a21a26da/nav2_bringup/bringup/launch/bringup_launch.py#L39

---

Also, this will probably require configuration files in `/turtlebot3_navigation2/param/` to be updated (I will try to edit them as well).