### PR TITLE
Added dwa-local-planner dependency

### DIFF
--- a/turtlebot3_navigation/package.xml
+++ b/turtlebot3_navigation/package.xml
@@ -18,6 +18,7 @@
   <buildtool_depend>catkin</buildtool_depend>
   <exec_depend>amcl</exec_depend>
   <exec_depend>map_server</exec_depend>
+  <exec_depend>dwa_local_planner</exec_depend>
   <exec_depend>move_base</exec_depend>
   <exec_depend>turtlebot3_bringup</exec_depend>
 </package>


### PR DESCRIPTION
When using the turtlebot-navigation, I got the following error:

`[FATAL] [1605168053.752173806, 77.968000000]: Failed to create the dwa_local_planner/DWAPlannerROS planner, are you sure it is properly registered and that the containing library is built? Exception: According to the loaded plugin descriptions the class dwa_local_planner/DWAPlannerROS with base class type nav_core::BaseLocalPlanner does not exist. Declared types are  base_local_planner/TrajectoryPlannerROS`

This is resolved by adding the dwa-local-planner to the exec-dependency. This pull request will add the dependency.