### PR TITLE
Adding slash to prefixes to accomodate #139 at robot_state_publisher

### DIFF
--- a/turtlebot3_bringup/launch/turtlebot3_remote.launch
+++ b/turtlebot3_bringup/launch/turtlebot3_remote.launch
@@ -8,6 +8,6 @@
 
   <node pkg="robot_state_publisher" type="robot_state_publisher" name="robot_state_publisher">
     <param name="publish_frequency" type="double" value="50.0" />
-    <param name="tf_prefix" value="$(arg multi_robot_name)"/>
+    <param name="tf_prefix" value="$(arg multi_robot_name)/"/>
   </node>
 </launch>


### PR DESCRIPTION
Signed-off-by: Aaron Chong <aaronchongth@gmail.com>

* support for `tf_prefix` in `robot_state_publisher` was dropped for `noetic`, however there are valid reasons to bring it back for multi-robot systems, following [this discussion](https://github.com/ros/robot_state_publisher/pull/139)
* Waiting on https://github.com/ros/robot_state_publisher/pull/139 to be merged, slashes will no longer be automatically appended to prefixes