### PR TITLE
Fix #736

### DIFF
--- a/turtlebot3_node/src/turtlebot3.cpp
+++ b/turtlebot3_node/src/turtlebot3.cpp
@@ -53,8 +53,8 @@ void TurtleBot3::init_dynamixel_sdk_wrapper(const std::string & usb_port)
 {
   DynamixelSDKWrapper::Device opencr = {usb_port, 200, 1000000, 2.0f};
 
-  this->declare_parameter<uint8_t>("opencr.id");
-  this->declare_parameter<uint32_t>("opencr.baud_rate");
+  this->declare_parameter<int64_t>("opencr.id");
+  this->declare_parameter<int64_t>("opencr.baud_rate");
   this->declare_parameter<float>("opencr.protocol_version");
 
   this->get_parameter_or<uint8_t>("opencr.id", opencr.id, 200);
@@ -142,8 +142,8 @@ void TurtleBot3::add_sensors()
 {
   RCLCPP_INFO(this->get_logger(), "Add Sensors");
 
-  this->declare_parameter<uint8_t>("sensors.bumper_1");
-  this->declare_parameter<uint8_t>("sensors.bumper_2");
+  this->declare_parameter<int64_t>("sensors.bumper_1");
+  this->declare_parameter<int64_t>("sensors.bumper_2");
 
   this->declare_parameter<float>("sensors.illumination");
 


### PR DESCRIPTION
The reason for error #736 was that in rclcpp there is no exact match for `uint8_t` type. In other words, we have to use one of the types defined [here](https://github.com/ros2/rclcpp/blob/55d2f67b9017dc1307c221dc7e0f7b90f083cdb0/rclcpp/include/rclcpp/parameter_value.hpp#L77-L121).

P.S. I'm not an expert, so please verify nothing breaks by this.

P.S. 2 — Check out this little example:
```
#include <cinttypes>

class A
{
    public:
    explicit A(int a) {}
    explicit A(int64_t a) {}
};

int main()
{
    A* a;
    a = new A((int)3);
    a = new A((int64_t)3);
    a = new A((unsigned int)3);
}
```
which generates this error in the last line of `main()`:
```
a.cpp: In function ‘int main()’:
a.cpp:16:30: error: call of overloaded ‘A(unsigned int)’ is ambiguous
   16 |     a = new A((unsigned int)3);
      |                              ^
a.cpp:7:14: note: candidate: ‘A::A(int64_t)’
    7 |     explicit A(int64_t a) {}
      |              ^
a.cpp:6:14: note: candidate: ‘A::A(int)’
    6 |     explicit A(int a) {}
      |              ^
a.cpp:3:7: note: candidate: ‘constexpr A::A(const A&)’
    3 | class A
      |       ^
a.cpp:3:7: note: candidate: ‘constexpr A::A(A&&)’
```