### PR TITLE
Make RViz optional

### DIFF
--- a/turtlebot3_cartographer/launch/cartographer.launch.py
+++ b/turtlebot3_cartographer/launch/cartographer.launch.py
@@ -17,6 +17,7 @@
 import os
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
+from launch.conditions import IfCondition
 from launch.actions import DeclareLaunchArgument
 from launch_ros.actions import Node
 from launch.substitutions import LaunchConfiguration
@@ -26,6 +27,7 @@ from launch.substitutions import ThisLaunchFileDir
 
 
 def generate_launch_description():
+    use_rviz = LaunchConfiguration('use_rviz', default='true')
     use_sim_time = LaunchConfiguration('use_sim_time', default='false')
     turtlebot3_cartographer_prefix = get_package_share_directory('turtlebot3_cartographer')
     cartographer_config_dir = LaunchConfiguration('cartographer_config_dir', default=os.path.join(
@@ -84,5 +86,6 @@ def generate_launch_description():
             name='rviz2',
             arguments=['-d', rviz_config_dir],
             parameters=[{'use_sim_time': use_sim_time}],
+            condition=IfCondition(use_rviz),
             output='screen'),
     ])

--- a/turtlebot3_navigation2/launch/navigation2.launch.py
+++ b/turtlebot3_navigation2/launch/navigation2.launch.py
@@ -18,6 +18,7 @@ import os
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
+from launch.conditions import IfCondition
 from launch.actions import DeclareLaunchArgument
 from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
@@ -28,6 +29,7 @@ TURTLEBOT3_MODEL = os.environ['TURTLEBOT3_MODEL']
 
 
 def generate_launch_description():
+    use_rviz = LaunchConfiguration('use_rviz', default='true')
     use_sim_time = LaunchConfiguration('use_sim_time', default='false')
     map_dir = LaunchConfiguration(
         'map',
@@ -81,5 +83,6 @@ def generate_launch_description():
             name='rviz2',
             arguments=['-d', rviz_config_dir],
             parameters=[{'use_sim_time': use_sim_time}],
+            condition=IfCondition(use_rviz),
             output='screen'),
     ])


### PR DESCRIPTION
We are running some system tests in CI built on top of the TurtleBot package and RViz makes problems. It would be much convenient to have RViz as an optional node. This feature would also help users who want to build an application on top of the navigation/mapping TurtleBot packages.