### PR TITLE
add cff citation file, so others can cite turtlebot3 repo

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,12 @@
+# This CITATION.cff file was generated with cffinit.
+# Visit https://bit.ly/cffinit to generate yours today!
+
+cff-version: 1.2.0
+title: TurtleBot 3
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+type: software
+authors:
+  - given-names: ROBOTIS
+    affiliation: ROTOTIS


### PR DESCRIPTION
Includes a [.cff citation](https://citation-file-format.github.io/) file, in order to enable others to get the software bibtex citation directly from github.