### PR TITLE
Update move_base.launch

### DIFF
--- a/turtlebot3_navigation/launch/move_base.launch
+++ b/turtlebot3_navigation/launch/move_base.launch
@@ -1,7 +1,7 @@
 <launch>
   <!-- Arguments -->
   <arg name="model" default="$(env TURTLEBOT3_MODEL)" doc="model type [burger, waffle, waffle_pi]"/>
-  <arg name="cmd_vel_topic" default="/cmd_vel" />
+  <arg name="cmd_vel_topic" default="cmd_vel" />
   <arg name="odom_topic" default="odom" />
   <arg name="move_forward_only" default="false"/>
 


### PR DESCRIPTION
Made `cmd_vel_topic` sensitive to namespaces. When having `/cmd_vel`, the topic always gets created outside of a namespace quasi as "root", while it should be in `/namespace/cmd_vel`.
For `odom` this already works.