### PR TITLE
Fix AMCL robot model type params

### DIFF
--- a/turtlebot3_navigation2/param/burger.yaml
+++ b/turtlebot3_navigation2/param/burger.yaml
@@ -26,7 +26,7 @@ amcl:
     recovery_alpha_fast: 0.0
     recovery_alpha_slow: 0.0
     resample_interval: 1
-    robot_model_type: "differential"
+    robot_model_type: "nav2_amcl::DifferentialMotionModel"
     save_pose_rate: 0.5
     sigma_hit: 0.2
     tf_broadcast: true

--- a/turtlebot3_navigation2/param/waffle.yaml
+++ b/turtlebot3_navigation2/param/waffle.yaml
@@ -26,7 +26,7 @@ amcl:
     recovery_alpha_fast: 0.0
     recovery_alpha_slow: 0.0
     resample_interval: 1
-    robot_model_type: "differential"
+    robot_model_type: "nav2_amcl::DifferentialMotionModel"
     save_pose_rate: 0.5
     sigma_hit: 0.2
     tf_broadcast: true

--- a/turtlebot3_navigation2/param/waffle_pi.yaml
+++ b/turtlebot3_navigation2/param/waffle_pi.yaml
@@ -26,7 +26,7 @@ amcl:
     recovery_alpha_fast: 0.0
     recovery_alpha_slow: 0.0
     resample_interval: 1
-    robot_model_type: "differential"
+    robot_model_type: "nav2_amcl::DifferentialMotionModel"
     save_pose_rate: 0.5
     sigma_hit: 0.2
     tf_broadcast: true


### PR DESCRIPTION
As discussed in https://github.com/ROBOTIS-GIT/turtlebot3/issues/884, specifically in my comment here: https://github.com/ROBOTIS-GIT/turtlebot3/issues/884#issuecomment-1295964374

According to [the official Nav2 documentation](https://navigation.ros.org/configuration/packages/configuring-amcl.html#parameters#robot_model_type:~:text=string-,%E2%80%9Cnav2_amcl%3A%3ADifferentialMotionModel%E2%80%9D,-Description), there is a note saying:

```
Note for users of galactic and earlier
The models are selectable by string key (valid options: “differential”, “omnidirectional”) rather than plugins.
```

... which is why that everyone going to Humble has their TurtleBot3 Nav2 example broken. So, we should be using `nav2_amcl::DifferentialMotionModel`.

I tested locally by modifying the params files in Humble and it resolves my issue.