### PR TITLE
Fixed Odometry step_time calculation

### DIFF
--- a/turtlebot3_node/include/turtlebot3_node/odometry.hpp
+++ b/turtlebot3_node/include/turtlebot3_node/odometry.hpp
@@ -81,6 +81,8 @@ private:
 
   double wheels_separation_;
   double wheels_radius_;
+  uint32_t last_time_;
+
 
   std::string frame_id_of_odometry_;
   std::string child_frame_id_of_odometry_;

--- a/turtlebot3_node/src/odometry.cpp
+++ b/turtlebot3_node/src/odometry.cpp
@@ -108,15 +108,14 @@ Odometry::Odometry(
 
 void Odometry::joint_state_callback(const sensor_msgs::msg::JointState::SharedPtr joint_state_msg)
 {
-  static rclcpp::Time last_time = joint_state_msg->header.stamp;
   rclcpp::Duration duration(rclcpp::Duration::from_nanoseconds(
-      joint_state_msg->header.stamp.nanosec - last_time.nanoseconds()));
+      joint_state_msg->header.stamp.nanosec - last_time_));
 
   update_joint_state(joint_state_msg);
   calculate_odometry(duration);
   publish(joint_state_msg->header.stamp);
 
-  last_time = joint_state_msg->header.stamp;
+  last_time_ = joint_state_msg->header.stamp.nanosec;
 }
 
 void Odometry::joint_state_and_imu_callback(
@@ -129,16 +128,15 @@ void Odometry::joint_state_and_imu_callback(
     joint_state_msg->header.stamp.nanosec,
     imu_msg->header.stamp.nanosec);
 
-  static rclcpp::Time last_time = joint_state_msg->header.stamp;
   rclcpp::Duration duration(rclcpp::Duration::from_nanoseconds(
-      joint_state_msg->header.stamp.nanosec - last_time.nanoseconds()));
+      joint_state_msg->header.stamp.nanosec - last_time_));
 
   update_joint_state(joint_state_msg);
   update_imu(imu_msg);
   calculate_odometry(duration);
   publish(joint_state_msg->header.stamp);
 
-  last_time = joint_state_msg->header.stamp;
+  last_time_ = joint_state_msg->header.stamp.nanosec;
 }
 
 void Odometry::publish(const rclcpp::Time & now)


### PR DESCRIPTION
The calculation for the step_time in the Odometry.cpp was comparing builtin_interfaces/msg/Time nanosec the nanosecond component of that message to rclcpp::Time nanoseconds() which is a absolute measure of time in nanoseconds.
This lead to step_time being negativ, in tern flipping the sign of the resulting odometry.

Additionally the last_time variable was set to msg time before calculation, not after.

I created a private uint32 last_time_ in Odometry.hpp, and switched the calculations to use the msg/Time nanosec value. This will result in bad behaviour if the time difference is larger than 1 sec. But for my use case that is not a Problem 