### PR TITLE
fixed the problem that /odom/twist is too small

### DIFF
--- a/turtlebot3_node/src/odometry.cpp
+++ b/turtlebot3_node/src/odometry.cpp
@@ -109,15 +109,14 @@ Odometry::Odometry(
 void Odometry::joint_state_callback(const sensor_msgs::msg::JointState::SharedPtr joint_state_msg)
 {
   const rclcpp::Time current_time = joint_state_msg->header.stamp;
-  static rclcpp::Time last_time = joint_state_msg->header.stamp;
-  rclcpp::Duration duration(rclcpp::Duration::from_nanoseconds(
-      current_time.nanoseconds() - last_time.nanoseconds()));
+  static rclcpp::Time last_time = current_time;
+  const rclcpp::Duration duration = current_time - last_time;
 
   update_joint_state(joint_state_msg);
   calculate_odometry(duration);
-  publish(joint_state_msg->header.stamp);
+  publish(current_time);
 
-  last_time = joint_state_msg->header.stamp;
+  last_time = current_time;
 }
 
 void Odometry::joint_state_and_imu_callback(
@@ -131,16 +130,15 @@ void Odometry::joint_state_and_imu_callback(
     imu_msg->header.stamp.nanosec);
 
   const rclcpp::Time current_time = joint_state_msg->header.stamp;
-  static rclcpp::Time last_time = joint_state_msg->header.stamp;
-  rclcpp::Duration duration(rclcpp::Duration::from_nanoseconds(
-      current_time.nanoseconds() - last_time.nanoseconds()));
+  static rclcpp::Time last_time = current_time;
+  const rclcpp::Duration duration = current_time - last_time;
 
   update_joint_state(joint_state_msg);
   update_imu(imu_msg);
   calculate_odometry(duration);
-  publish(joint_state_msg->header.stamp);
+  publish(current_time);
 
-  last_time = joint_state_msg->header.stamp;
+  last_time = current_time;
 }
 
 void Odometry::publish(const rclcpp::Time & now)

--- a/turtlebot3_node/src/odometry.cpp
+++ b/turtlebot3_node/src/odometry.cpp
@@ -108,9 +108,10 @@ Odometry::Odometry(
 
 void Odometry::joint_state_callback(const sensor_msgs::msg::JointState::SharedPtr joint_state_msg)
 {
+  const rclcpp::Time current_time = joint_state_msg->header.stamp;
   static rclcpp::Time last_time = joint_state_msg->header.stamp;
   rclcpp::Duration duration(rclcpp::Duration::from_nanoseconds(
-      joint_state_msg->header.stamp.nanosec - last_time.nanoseconds()));
+      current_time.nanoseconds() - last_time.nanoseconds()));
 
   update_joint_state(joint_state_msg);
   calculate_odometry(duration);
@@ -129,9 +130,10 @@ void Odometry::joint_state_and_imu_callback(
     joint_state_msg->header.stamp.nanosec,
     imu_msg->header.stamp.nanosec);
 
+  const rclcpp::Time current_time = joint_state_msg->header.stamp;
   static rclcpp::Time last_time = joint_state_msg->header.stamp;
   rclcpp::Duration duration(rclcpp::Duration::from_nanoseconds(
-      joint_state_msg->header.stamp.nanosec - last_time.nanoseconds()));
+      current_time.nanoseconds() - last_time.nanoseconds()));
 
   update_joint_state(joint_state_msg);
   update_imu(imu_msg);


### PR DESCRIPTION
This fixes #977 .

### Problem
In the duration calculation, only the "nanosec" part of  "current time" was used and "sec" part was ignored. On the other hand both "nanosec" and "sec" part of "last time"  were used correctly.

Therefore, duration became a negative value with a large absolute value, and as a result, the twist had a small absolute value with the opposite sign.

### Solution
Fixed calculation of duration to be correct.