### PR TITLE
Make Rviz of navigation2 and cartographer optional

### DIFF
--- a/turtlebot3_cartographer/launch/cartographer.launch.py
+++ b/turtlebot3_cartographer/launch/cartographer.launch.py
@@ -17,6 +17,7 @@
 import os
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
+from launch.conditions import IfCondition
 from launch.actions import DeclareLaunchArgument
 from launch_ros.actions import Node
 from launch.substitutions import LaunchConfiguration
@@ -27,6 +28,7 @@ from launch.substitutions import ThisLaunchFileDir
 
 def generate_launch_description():
     use_sim_time = LaunchConfiguration('use_sim_time', default='false')
+    use_rviz = LaunchConfiguration('use_rviz', default='true')
     turtlebot3_cartographer_prefix = get_package_share_directory('turtlebot3_cartographer')
     cartographer_config_dir = LaunchConfiguration('cartographer_config_dir', default=os.path.join(
                                                   turtlebot3_cartographer_prefix, 'config'))
@@ -84,5 +86,6 @@ def generate_launch_description():
             name='rviz2',
             arguments=['-d', rviz_config_dir],
             parameters=[{'use_sim_time': use_sim_time}],
+            condition=IfCondition(use_rviz),
             output='screen'),
     ])

--- a/turtlebot3_navigation2/launch/navigation2.launch.py
+++ b/turtlebot3_navigation2/launch/navigation2.launch.py
@@ -18,6 +18,7 @@ import os
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
+from launch.conditions import IfCondition
 from launch.actions import DeclareLaunchArgument
 from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
@@ -29,6 +30,7 @@ TURTLEBOT3_MODEL = os.environ['TURTLEBOT3_MODEL']
 
 def generate_launch_description():
     use_sim_time = LaunchConfiguration('use_sim_time', default='false')
+    use_rviz = LaunchConfiguration('use_rviz', default='true')
     map_dir = LaunchConfiguration(
         'map',
         default=os.path.join(
@@ -81,5 +83,6 @@ def generate_launch_description():
             name='rviz2',
             arguments=['-d', rviz_config_dir],
             parameters=[{'use_sim_time': use_sim_time}],
+            condition=IfCondition(use_rviz),
             output='screen'),
     ])


### PR DESCRIPTION
**Issue** : # https://github.com/ROBOTIS-GIT/turtlebot3/issues/946
**fix** : Added the use_rviz parameter to the launch files of navigation2 and Cartographer, enabling optional use of RViz.
**reference** : https://github.com/ROBOTIS-GIT/turtlebot3/pull/799 , 8ea1f0d842a34a26f8cf87d39968b6edf80bbc96