### PR TITLE
Change version of DynamicSDK in turtlebot3_ci.repos and turtlebot3.repos

### DIFF
--- a/turtlebot3.repos
+++ b/turtlebot3.repos
@@ -14,7 +14,7 @@ repositories:
   utils/DynamixelSDK:
     type: git
     url: https://github.com/ROBOTIS-GIT/DynamixelSDK.git
-    version: main
+    version: humble
   utils/hls_lfcd_lds_driver:
     type: git
     url: https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver.git

--- a/turtlebot3_bringup/launch/robot.launch.py
+++ b/turtlebot3_bringup/launch/robot.launch.py
@@ -25,7 +25,8 @@ from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 from launch.substitutions import PythonExpression, ThisLaunchFileDir
-from launch_ros.actions import Node, PushRosNamespace
+from launch_ros.actions import Node
+from launch_ros.actions import PushRosNamespace
 
 
 def generate_launch_description():

--- a/turtlebot3_bringup/package.xml
+++ b/turtlebot3_bringup/package.xml
@@ -14,6 +14,7 @@
   <author email="thlim@robotis.com">Darby Lim</author>
   <author email="pyo@robotis.com">Pyo</author>
   <author email="willson@robotis.com">Will Son</author>
+  <author email="kimhg@robotis.com">Hyungyu</author>
   <buildtool_depend>ament_cmake</buildtool_depend>
   <exec_depend>hls_lfcd_lds_driver</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>

--- a/turtlebot3_ci.repos
+++ b/turtlebot3_ci.repos
@@ -6,7 +6,7 @@ repositories:
   utils/DynamixelSDK:
     type: git
     url: https://github.com/ROBOTIS-GIT/DynamixelSDK.git
-    version: main
+    version: humble
   utils/hls_lfcd_lds_driver:
     type: git
     url: https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver.git


### PR DESCRIPTION
This change makes the CI fetch the Dynamic SDK from the Humble branch when checking dependencies.