### PR TITLE
Allow dynamic image size via CLI

### DIFF
--- a/turtlebot3/CHANGELOG.rst
+++ b/turtlebot3/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog for package turtlebot3
 
 2.3.0 (2025-05-23)
 ------------------
-* Added a launch file using camera_ros to reslove the camera cropping issue
+* Added a launch file using camera_ros to resolve the camera cropping issue
 * Contributor: YeonSoo Noh
 
 2.2.9 (2025-04-15)

--- a/turtlebot3_bringup/CHANGELOG.rst
+++ b/turtlebot3_bringup/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog for package turtlebot3_bringup
 
 2.3.0 (2025-05-23)
 ------------------
-* Added a launch file using camera_ros to reslove the camera cropping issue
+* Added a launch file using camera_ros to resolve the camera cropping issue
 * Contributor: YeonSoo Noh
 
 2.2.9 (2025-04-15)

--- a/turtlebot3_bringup/launch/camera.launch.py
+++ b/turtlebot3_bringup/launch/camera.launch.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python3
-#
+# Copyright 2021 Christian Rauch
 # Copyright 2025 ROBOTIS CO., LTD.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +12,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# Portions of this file are based on https://github.com/christianrauch/camera_ros
+# Originally licensed under the MIT License
 
 
 from ament_index_python.resources import has_resource
@@ -61,6 +63,24 @@ def generate_launch_description() -> LaunchDescription:
         description='Whether to launch image_view (true/false)'
     )
 
+    width_name = 'width'
+    width_default = '640'
+    width_param = LaunchConfiguration(width_name)
+    width_launch_arg = DeclareLaunchArgument(
+        width_name,
+        default_value=width_default,
+        description='Camera image width'
+    )
+
+    height_name = 'height'
+    height_default = '480'
+    height_param = LaunchConfiguration(height_name)
+    height_launch_arg = DeclareLaunchArgument(
+        height_name,
+        default_value=height_default,
+        description='Camera image height'
+    )
+
     composable_nodes = [
         ComposableNode(
             package='camera_ros',
@@ -68,8 +88,8 @@ def generate_launch_description() -> LaunchDescription:
             parameters=[{
                 'camera': camera_param,
                 'sensor_mode': '1640:1232',
-                'width': 320,
-                'height': 240,
+                'width': width_param,
+                'height': height_param,
                 'format': format_param,
             }],
             extra_arguments=[{'use_intra_process_comms': True}],
@@ -99,5 +119,7 @@ def generate_launch_description() -> LaunchDescription:
         camera_launch_arg,
         format_launch_arg,
         use_image_view_launch_arg,
+        width_launch_arg,
+        height_launch_arg,
         container,
     ])


### PR DESCRIPTION
This PR adds launch arguments width and height to the camera.launch.py file, allowing users to configure the camera image resolution at runtime via the CLI.